### PR TITLE
Upload a wheel to PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
You can achieve this by installing the wheel package and running `python setup.py register bdist_wheel upload` in your natsort directory. It can also be combined with your existing source distribution uploads like so `python setup.py register sdist bdist_wheel upload`.

This change makes the generated wheel compatible with both python 2 and 3.
