### PR TITLE
Fixed import bug when using python -OO.

### DIFF
--- a/natsort/compat/py23.py
+++ b/natsort/compat/py23.py
@@ -90,7 +90,8 @@ def _modify_str_or_docstring(str_change_func):
             func = func_or_str
             doc = func.__doc__
 
-        doc = str_change_func(doc)
+        if doc is not None:
+            doc = str_change_func(doc)
 
         if func:
             func.__doc__ = doc


### PR DESCRIPTION
The -OO flag removes docstrings (sets them to None), which caused
issues with the doctoring compatability wrapper because it was trying
to call .format on None.

The wrapper has been modified to check for None.

This should solve issue #38.