### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ url = https://github.com/SethMMorton/natsort
 description = Simple yet flexible natural sorting in Python.
 long_description = file: README.rst
 license = MIT
+license_file = LICENSE
 classifiers = 
 	Development Status :: 5 - Production/Stable
 	Intended Audience :: Developers


### PR DESCRIPTION
The wheel package format supports including the license file. This is
done using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Helps project comply with its own license:

> The above copyright notice and this permission notice shall be
> included in all copies or substantial portions of the Software.