### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/docs/source/howitworks.rst
+++ b/docs/source/howitworks.rst
@@ -938,7 +938,7 @@ So, how to deal with this situation? There are two ways to do so.
     turn on *LOWERCASEFIRST* and *GROUPLETTERS*.
 #.  Use an alternate library if installed. `ICU <http://site.icu-project.org/>`_
     is a great and powerful library that has a pretty decent Python port
-    called (you guessed it) `PyICU <https://pypi.python.org/pypi/PyICU/>`_.
+    called (you guessed it) `PyICU <https://pypi.org/project/PyICU/>`_.
     If a user has this library installed on their computer, :mod:`natsort`
     chooses to use that instead of :mod:`locale`. With a little bit of
     planning, one can write a set of wrapper functions that call

--- a/docs/source/locale_issues.rst
+++ b/docs/source/locale_issues.rst
@@ -39,7 +39,7 @@ independent of the global state, but the
 function must access this global state to work; therefore, if you change
 locale and use ``ns.LOCALE`` then you should discard the old key.
 
-.. note:: If you use `PyICU <https://pypi.python.org/pypi/PyICU>`_ then you
+.. note:: If you use `PyICU <https://pypi.org/project/PyICU/>`_ then you
           may be able to reuse keys after changing locale.
 
 The `locale <https://docs.python.org/3.5/library/locale.html>`_ Module From the StdLib Has Issues


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html