### PR TITLE
Correct highlighting language in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ When you try to sort a list of strings that contain numbers, the normal python
 sort algorithm sorts lexicographically, so you might not get the results that you
 expect:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
     >>> sorted(a)
@@ -57,7 +57,7 @@ letters (i.e. 'b', 'ba', 'c').
 sorting based on meaning and not computer code point).
 Using ``natsorted`` is simple:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import natsorted
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
@@ -75,7 +75,7 @@ for a quick start guide, or the
 To sort a list and assign the output to the same variable, you must
 explicitly assign the output to a variable:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
     >>> natsorted(a)
@@ -97,7 +97,7 @@ Sorting Versions
 
 This is handled properly by default (as of ``natsort`` version >= 4.0.0):
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['version-1.9', 'version-2.0', 'version-1.11', 'version-1.10']
     >>> natsorted(a)
@@ -113,7 +113,7 @@ This is useful in scientific data analysis and was
 the default behavior of ``natsorted`` for ``natsort``
 version < 4.0.0. Use the ``realsorted`` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import realsorted, ns
     >>> # Note that when interpreting as signed floats, the below numbers are
@@ -134,7 +134,7 @@ not on their ordinal value, and a locale-dependent thousands separator and decim
 separator is accounted for in the number.
 This can be achieved with the ``humansorted`` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['Apple', 'apple15', 'Banana', 'apple14,689', 'banana']
     >>> natsorted(a)
@@ -160,7 +160,7 @@ If you need to combine multiple algorithm modifiers (such as ``ns.REAL``,
 ``ns.LOCALE``, and ``ns.IGNORECASE``), you can combine the options using the
 bitwise OR operator (``|``). For example,
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['Apple', 'apple15', 'Banana', 'apple14,689', 'banana']
     >>> natsorted(a, alg=ns.REAL | ns.LOCALE | ns.IGNORECASE)
@@ -180,7 +180,7 @@ All of the available customizations can be found in the documentation for
 You can also add your own custom transformation functions with the ``key`` argument.
 These can be used with ``alg`` if you wish.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['apple2.50', '2.3apple']
     >>> natsorted(a, key=lambda x: x.replace('apple', ''), alg=ns.REAL)
@@ -192,7 +192,7 @@ Sorting Mixed Types
 You can mix and match ``int``, ``float``, and ``str`` (or ``unicode``) types
 when you sort:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['4.5', 6, 2.0, '5', 'a']
     >>> natsorted(a)
@@ -206,7 +206,7 @@ Handling Bytes on Python 3
 ``natsort`` does not officially support the `bytes` type on Python 3, but
 convenience functions are provided that help you decode to `str` first:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import as_utf8
     >>> a = [b'a', 14.0, 'b']
@@ -229,7 +229,7 @@ key using ``natsort_keygen`` and then passes that to the built-in
 generate a custom sorting key to sort in-place using the ``list.sort``
 method.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import natsort_keygen
     >>> natsort_key = natsort_keygen()
@@ -282,7 +282,7 @@ How *does* ``natsort`` work?
     key generator ``natsort.natsort_keygen()``.  ``natsort.natsorted()`` is essentially
     a wrapper for the following code:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> from natsort import natsort_keygen
         >>> natsort_key = natsort_keygen()
@@ -351,7 +351,7 @@ Installation
 
 Use ``pip``!
 
-.. code-block:: sh
+.. code-block:: console
 
     $ pip install natsort
 
@@ -361,7 +361,7 @@ at installation time to install those dependencies as well - use ``fast`` for
 `fastnumbers <https://pypi.org/project/fastnumbers>`_ and ``icu`` for
 `PyICU <https://pypi.org/project/PyICU>`_.
 
-.. code-block:: sh
+.. code-block:: console
 
     # Install both optional dependencies.
     $ pip install natsort[fast,icu]
@@ -377,7 +377,7 @@ The recommended way to run tests is with `tox <https://tox.readthedocs.io/en/lat
 After installing ``tox``, running tests is as simple as executing the following in the
 ``natsort`` directory:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ tox
 
@@ -390,7 +390,7 @@ tests manually using `pytest <https://docs.pytest.org/en/latest/>`_ - ``natsort`
 contains a ``Pipfile`` for use with `pipenv <https://github.com/pypa/pipenv>`_ that
 makes it easy for you to install the testing dependencies:
 
-.. code-block:: sh
+.. code-block:: console
 
     $ pipenv install --skip-lock --dev
     $ pipenv run python -m pytest

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -18,7 +18,7 @@ Basic Usage
 In the most basic use case, simply import :func:`~natsorted` and use
 it as you would :func:`sorted`:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
     >>> sorted(a)
@@ -42,7 +42,7 @@ Sorting with Alpha, Beta, and Release Candidates
 By default, if you wish to sort versions with a non-strict versioning
 scheme, you may not get the results you expect:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['1.2', '1.2rc1', '1.2beta2', '1.2beta1', '1.2alpha', '1.2.1', '1.1', '1.3']
     >>> natsorted(a)
@@ -51,7 +51,7 @@ scheme, you may not get the results you expect:
 To make the '1.2' pre-releases come before '1.2.1', you need to use the following
 recipe:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, key=lambda x: x.replace('.', '~'))
     ['1.1', '1.2', '1.2alpha', '1.2beta1', '1.2beta2', '1.2rc1', '1.2.1', '1.3']
@@ -59,7 +59,7 @@ recipe:
 If you also want '1.2' after all the alpha, beta, and rc candidates, you can
 modify the above recipe:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, key=lambda x: x.replace('.', '~')+'z')
     ['1.1', '1.2alpha', '1.2beta1', '1.2beta2', '1.2rc1', '1.2', '1.2.1', '1.3']
@@ -76,7 +76,7 @@ In some cases when sorting file paths with OS-Generated names, the default
 :mod:`~natsorted` algorithm may not be sufficient.  In cases like these,
 you may need to use the ``ns.PATH`` option:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['./folder/file (1).txt',
     ...      './folder/file.txt',
@@ -100,7 +100,7 @@ characters, it will also properly interpret non-'.' decimal separators
 and also properly order case.  It may be more convenient to just use
 the :func:`humansorted` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import humansorted
     >>> import locale
@@ -125,7 +125,7 @@ Controlling Case When Sorting
 For non-numbers, by default :mod:`natsort` used ordinal sorting (i.e.
 it sorts by the character's value in the ASCII table).  For example:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['Apple', 'corn', 'Corn', 'Banana', 'apple', 'banana']
     >>> natsorted(a)
@@ -134,7 +134,7 @@ it sorts by the character's value in the ASCII table).  For example:
 There are times when you wish to ignore the case when sorting,
 you can easily do this with the ``ns.IGNORECASE`` option:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, alg=ns.IGNORECASE)
     ['Apple', 'apple', 'Banana', 'banana', 'corn', 'Corn']
@@ -147,7 +147,7 @@ Upper-case letters appear first in the ASCII table, but many natural
 sorting methods place lower-case first.  To do this, use
 ``ns.LOWERCASEFIRST``:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, alg=ns.LOWERCASEFIRST)
     ['apple', 'banana', 'corn', 'Apple', 'Banana', 'Corn']
@@ -157,7 +157,7 @@ and the lower-case letters grouped together; most would expect all
 "a"s to bet together regardless of case, and all "b"s, and so on. To
 achieve this, use ``ns.GROUPLETTERS``:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, alg=ns.GROUPLETTERS)
     ['Apple', 'apple', 'Banana', 'banana', 'Corn', 'corn']
@@ -165,7 +165,7 @@ achieve this, use ``ns.GROUPLETTERS``:
 You might combine this with ``ns.LOWERCASEFIRST`` to get what most
 would expect to be "natural" sorting:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, alg=ns.G | ns.LF)
     ['apple', 'Apple', 'banana', 'Banana', 'corn', 'Corn']
@@ -178,7 +178,7 @@ a valid Python float literal, such as 5, 0.4, -4.78, +4.2E-34, etc.
 using the ``ns.FLOAT`` key. You can disable the exponential component
 of the number with ``ns.NOEXP``.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['a50', 'a51.', 'a+50.4', 'a5.034e1', 'a+50.300']
     >>> natsorted(a, alg=ns.FLOAT)
@@ -195,7 +195,7 @@ function. Please note that the behavior of the :func:`~realsorted` function
 was the default behavior of :func:`~natsorted` for :mod:`natsort`
 version < 4.0.0:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> natsorted(a, alg=ns.REAL)
     ['a50', 'a+50.300', 'a5.034e1', 'a+50.4', 'a51.']
@@ -211,7 +211,7 @@ Using a Custom Sorting Key
 Like the built-in ``sorted`` function, ``natsorted`` can accept a custom
 sort key so that:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from operator import attrgetter, itemgetter
     >>> a = [['a', 'num4'], ['b', 'num8'], ['c', 'num2']]
@@ -233,7 +233,7 @@ If you need to sort a list in-place, you cannot use :func:`~natsorted`; you
 need to pass a key to the :meth:`list.sort` method. The function
 :func:`~natsort_keygen` is a convenient way to generate these keys for you:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import natsort_keygen
     >>> a = ['a50', 'a51.', 'a50.4', 'a5.034e1', 'a50.300']
@@ -256,7 +256,7 @@ Natural Sorting with ``cmp`` (Python 2 only)
 If you are using a legacy codebase that requires you to use :func:`cmp` instead
 of a key-function, you can use :func:`~natcmp`.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> import sys
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
@@ -279,7 +279,7 @@ To achieve this you could use the :func:`~index_natsorted` in combination
 with the convenience function
 :func:`~order_by_index`:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import index_natsorted, order_by_index
     >>> a = ['a2', 'a9', 'a1', 'a4', 'a10']
@@ -299,7 +299,7 @@ Returning Results in Reverse Order
 Just like the :func:`sorted` built-in function, you can supply the
 ``reverse`` option to return the results in reverse order:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['a2', 'a9', 'a1', 'a4', 'a10']
     >>> natsorted(a, reverse=True)
@@ -320,7 +320,7 @@ will allow :mod:`natsort` to convert byte arrays to strings for sorting;
 these functions know not to raise an error if the input is not a byte
 array, so you can use the key on any arbitrary collection of data.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import as_ascii
     >>> a = [b'a', 14.0, 'b']
@@ -335,7 +335,7 @@ run :mod:`natsort` on a list of bytes, you will get results that are like
 Python's default sorting behavior. Of course, you can use the decoding
 functions to solve this:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import as_utf8
     >>> a = [b'a56', b'a5', b'a6', b'a40']
@@ -347,7 +347,7 @@ functions to solve this:
 If you need a codec different from ASCII or UTF-8, you can use
 :func:`decoder` to generate a custom key:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import decoder
     >>> a = [b'a56', b'a5', b'a6', b'a40']

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -39,7 +39,7 @@ When you try to sort a list of strings that contain numbers, the normal python
 sort algorithm sorts lexicographically, so you might not get the results that you
 expect:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
     >>> sorted(a)
@@ -54,7 +54,7 @@ letters (i.e. 'b', 'ba', 'c').
 sorting based on meaning and not computer code point)..
 Using :func:`~natsorted` is simple:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import natsorted
     >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
@@ -73,7 +73,7 @@ for more details).
     `does not sort in-place`. To sort a list and assign the output to the
     same variable, you must explicitly assign the output to a variable:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
         >>> natsorted(a)
@@ -95,7 +95,7 @@ Sorting Versions
 
 This is handled properly by default (as of :mod:`natsort` version >= 4.0.0):
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['version-1.9', 'version-2.0', 'version-1.11', 'version-1.10']
     >>> natsorted(a)
@@ -111,7 +111,7 @@ This is useful in scientific data analysis and was
 the default behavior of :func:`~natsorted` for :mod:`natsort`
 version < 4.0.0. Use the :func:`~realsorted` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import realsorted, ns
     >>> # Note that when interpreting as signed floats, the below numbers are
@@ -132,7 +132,7 @@ not on their ordinal value, and a locale-dependent thousands separator and decim
 separator is accounted for in the number.
 This can be achieved with the :func:`~humansorted` function:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['Apple', 'apple15', 'Banana', 'apple14,689', 'banana']
     >>> natsorted(a)
@@ -158,7 +158,7 @@ If you need to combine multiple algorithm modifiers (such as ``ns.REAL``,
 ``ns.LOCALE``, and ``ns.IGNORECASE``), you can combine the options using the
 bitwise OR operator (``|``). For example,
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['Apple', 'apple15', 'Banana', 'apple14,689', 'banana']
     >>> natsorted(a, alg=ns.REAL | ns.LOCALE | ns.IGNORECASE)
@@ -178,7 +178,7 @@ the :class:`~natsort.ns` enum.
 You can also add your own custom transformation functions with the ``key`` argument.
 These can be used with ``alg`` if you wish:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['apple2.50', '2.3apple']
     >>> natsorted(a, key=lambda x: x.replace('apple', ''), alg=ns.REAL)
@@ -190,7 +190,7 @@ Sorting Mixed Types
 You can mix and match ``int``, ``float``, and ``str`` (or ``unicode``) types
 when you sort:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> a = ['4.5', 6, 2.0, '5', 'a']
     >>> natsorted(a)
@@ -204,7 +204,7 @@ Handling Bytes on Python 3
 :mod:`natsort` does not officially support the `bytes` type on Python 3, but
 convenience functions are provided that help you decode to `str` first:
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import as_utf8
     >>> a = [b'a', 14.0, 'b']
@@ -227,7 +227,7 @@ key using :func:`~natsort_keygen` and then passes that to the built-in
 generate a custom sorting key to sort in-place using the :meth:`list.sort`
 method.
 
-.. code-block:: python
+.. code-block:: pycon
 
     >>> from natsort import natsort_keygen
     >>> natsort_key = natsort_keygen()
@@ -280,7 +280,7 @@ How *does* :mod:`natsort` work?
     key generator :func:`natsort.natsort_keygen`.  :func:`natsort.natsorted` is essentially
     a wrapper for the following code:
 
-    .. code-block:: python
+    .. code-block:: pycon
 
         >>> from natsort import natsort_keygen
         >>> natsort_key = natsort_keygen()

--- a/docs/source/locale_issues.rst
+++ b/docs/source/locale_issues.rst
@@ -61,7 +61,9 @@ Explicitly Set the Locale Before Using :func:`~natsort.humansorted` or ``ns.LOCA
 I have found that unless you explicitly set a locale, the sorted order may not
 be what you expect. Setting this is straightforward
 (in the below example I use 'en_US.UTF-8', but you should use your
-locale)::
+locale):
+
+.. code-block:: pycon
 
     >>> import locale
     >>> locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')

--- a/docs/source/shell.rst
+++ b/docs/source/shell.rst
@@ -14,7 +14,7 @@ Below is the usage and some usage examples for the ``natsort`` shell script.
 Usage
 -----
 
-::
+.. code-block:: none
 
     usage: natsort [-h] [--version] [-p] [-f LOW HIGH] [-F LOW HIGH] [-e EXCLUDE]
                    [-r] [-t {digit,int,float,version,ver}] [--nosign] [--noexp]
@@ -74,7 +74,9 @@ Description
 
 ``natsort`` was originally written to aid in computational chemistry
 research so that it would be easy to analyze large sets of output files
-named after the parameter used::
+named after the parameter used:
+
+.. code-block:: console
 
     $ ls *.out
     mode1000.35.out mode1243.34.out mode744.43.out mode943.54.out
@@ -83,7 +85,9 @@ named after the parameter used::
 that the shell sorts in lexicographical order.  This is the behavior of programs like
 ``find`` as well as ``ls``.  The problem is passing these files to an
 analysis program causes them not to appear in numerical order, which can lead
-to bad analysis.  To remedy this, use ``natsort``::
+to bad analysis.  To remedy this, use ``natsort``:
+
+.. code-block:: console
 
     $ natsort *.out
     mode744.43.out
@@ -93,11 +97,15 @@ to bad analysis.  To remedy this, use ``natsort``::
     $ natsort -t r *.out | xargs your_program
 
 ``-t r`` is short for ``--number-type real``. You can also place natsort in
-the middle of a pipe::
+the middle of a pipe:
+
+.. code-block:: console
 
     $ find . -name "*.out" | natsort -t r | xargs your_program
 
-To sort version numbers, use the default ``--number-type``::
+To sort version numbers, use the default ``--number-type``:
+
+.. code-block:: console
 
     $ ls *
     prog-1.10.zip prog-1.9.zip prog-2.0.zip
@@ -108,7 +116,9 @@ To sort version numbers, use the default ``--number-type``::
 
 In general, all ``natsort`` shell script options mirror the :func:`~natsorted` API,
 with notable exception of the ``--filter``, ``--reverse-filter``, and ``--exclude``
-options.  These three options are used as follows::
+options.  These three options are used as follows:
+
+.. code-block:: console
 
     $ ls *.out
     mode1000.35.out mode1243.34.out mode744.43.out mode943.54.out
@@ -124,7 +134,9 @@ options.  These three options are used as follows::
     mode1243.34.out
 
 If you are sorting paths with OS-generated filenames, you may require the
-``--paths``/``-p`` option::
+``--paths``/``-p`` option:
+
+.. code-block:: console
 
     $ find . ! -path . -type f
     ./folder/file (1).txt


### PR DESCRIPTION
- Use pycon for Python console.
- Use console for Bash console.
- Use none for --help output

Fixes Sphinx warning of the form:

```
  natsort/docs/source/howitworks.rst:176: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/howitworks.rst:231: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/howitworks.rst:249: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/shell.rst:79: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/shell.rst:88: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/shell.rst:98: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/shell.rst:102: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/shell.rst:113: WARNING: Could not lex literal_block as "python". Highlighting skipped.
  natsort/docs/source/shell.rst:129: WARNING: Could not lex literal_block as "python". Highlighting skipped.
```

For a full list of supported lexers, see: http://pygments.org/docs/lexers/