### PR TITLE
Use intershpinx to build links to Python docs

### DIFF
--- a/docs/howitworks.rst
+++ b/docs/howitworks.rst
@@ -356,7 +356,8 @@ can see why this happens:
 
 This isn't very convenient... how do we solve it? We can split the path
 across the path separators and then sort. A convenient way do to this is
-with the `Path.parts`_ method from :mod:`pathlib`:
+with the :data:`Path.parts <pathlib.PurePath.parts>` property from
+:mod:`pathlib`:
 
 .. code-block:: pycon
 
@@ -365,8 +366,9 @@ with the `Path.parts`_ method from :mod:`pathlib`:
     ['/p/Folder/file.tar.gz', '/p/Folder (1)/file (1).tar.gz', '/p/Folder (1)/file.tar.gz', '/p/Folder (10)/file.tar.gz']
 
 Almost! It seems like there is some funny business going on in the final
-filename component as well. We can solve that nicely and quickly with `Path.suffixes`_
-and `Path.stem`_.
+filename component as well. We can solve that nicely and quickly with
+:data:`Path.suffixes <pathlib.PurePath.suffixes>` and :data:`Path.stem
+<pathlib.PurePath.stem>`.
 
 .. code-block:: pycon
 
@@ -1100,9 +1102,6 @@ what the rest of the world assumes.
 .. _The second major special case I encountered was sorting of different types: https://github.com/SethMMorton/natsort/issues/7
 .. _A rather unexpected special case I encountered was sorting collections containing NaN:
    https://github.com/SethMMorton/natsort/issues/27
-.. _Path.parts: https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.parts
-.. _Path.suffixes: https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.suffixes
-.. _Path.stem: https://docs.python.org/3/library/pathlib.html#pathlib.PurePath.stem
 .. _It's hard to compare floating point numbers: http://www.drdobbs.com/cpp/its-hard-to-compare-floating-point-numbe/240149806
 .. _caught a bit off guard when the request was initially made: https://github.com/SethMMorton/natsort/issues/14
 .. _at the code: https://github.com/SethMMorton/natsort/tree/master/natsort

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -271,12 +271,11 @@ How do I debug :func:`~natsorted`?
 How *does* :mod:`natsort` work?
     If you don't want to read :ref:`howitworks`, here is a quick primer.
 
-    :mod:`natsort` provides a `key function <https://docs.python.org/3/howto/sorting.html#key-functions>`_
-    that can be passed to `list.sort() <https://docs.python.org/3/library/stdtypes.html#list.sort>`_
-    or `sorted() <https://docs.python.org/3/library/functions.html#sorted>`_ in order to
-    modify the default sorting behavior. This key is generated on-demand with the
-    key generator :func:`natsort.natsort_keygen`.  :func:`natsort.natsorted` is essentially
-    a wrapper for the following code:
+    :mod:`natsort` provides a :term:`key function` that can be passed to
+    :meth:`list.sort` or :func:`sorted` in order to modify the default sorting
+    behavior. This key is generated on-demand with the key generator
+    :func:`natsort.natsort_keygen`. :func:`natsort.natsorted` is essentially a
+    wrapper for the following code:
 
     .. code-block:: pycon
 

--- a/docs/locale_issues.rst
+++ b/docs/locale_issues.rst
@@ -31,25 +31,23 @@ Corollary: Do Not Reuse :func:`~natsort.natsort_keygen` After Changing Locale
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 If you change locale, the old function will not work as expected.
-The `locale <https://docs.python.org/3.5/library/locale.html>`_ library works
-with a global state. When :func:`~natsort.natsort_keygen` is called it does the
-best job that it can to make the returned function as static as possible and
-independent of the global state, but the
-`strxfrm <https://docs.python.org/3.5/library/locale.html#locale.strxfrm>`_
-function must access this global state to work; therefore, if you change
-locale and use ``ns.LOCALE`` then you should discard the old key.
+The :mod:`locale` library works with a global state. When
+:func:`~natsort.natsort_keygen` is called it does the best job that it can to
+make the returned function as static as possible and independent of the global
+state, but the :func:`locale.strxfrm` function must access this global state to
+work; therefore, if you change locale and use ``ns.LOCALE`` then you should
+discard the old key.
 
 .. note:: If you use `PyICU`_ then you may be able to reuse keys after changing
           locale.
 
-The `locale <https://docs.python.org/3.5/library/locale.html>`_ Module From the StdLib Has Issues
--------------------------------------------------------------------------------------------------
+The :mod:`locale` Module From the StdLib Has Issues
+---------------------------------------------------
 
 :mod:`natsort` will use `PyICU`_ for :func:`~natsort.humansorted` or
-``ns.LOCALE`` if it is installed. If not, it will fall back on the `locale
-<https://docs.python.org/3.5/library/locale.html>`_ library from the Python
-stdlib. If you do not have `PyICU`_ installed, please keep the following known
-problems and issues in mind.
+``ns.LOCALE`` if it is installed. If not, it will fall back on the
+:mod:`locale` library from the Python stdlib. If you do not have `PyICU`_
+installed, please keep the following known problems and issues in mind.
 
 .. note:: Remember, if you have `PyICU`_ installed you shouldn't need to worry
           about any of these.
@@ -70,8 +68,8 @@ locale):
 
 .. _bug_note:
 
-The `locale <https://docs.python.org/3.5/library/locale.html>`_ Module Is Broken on Mac OS X
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+The :mod:`locale` Module Is Broken on Mac OS X
+++++++++++++++++++++++++++++++++++++++++++++++
 
 It's not Python's fault, but the OS... the locale library for BSD-based systems
 (of which Mac OS X is one) is broken. See the following links:


### PR DESCRIPTION
Automatically builds the correct URL so they do not need to be manually maintained.