### PR TITLE
Use skip_install=true for non-testing tox targets

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ deps =
     flake8-bugbear
     pep8-naming
 commands = flake8
+skip_install = true
 
 # Build documentation.
 [testenv:docs]
@@ -47,6 +48,7 @@ deps =
     sphinx_rtd_theme
 commands =
     {envpython} setup.py build_sphinx
+skip_install = true
 
 # Release the code to PyPI
 [testenv:release]
@@ -57,3 +59,4 @@ commands =
     check-manifest
     {envpython} setup.py sdist bdist_wheel
     twine upload dist/*
+skip_install = true


### PR DESCRIPTION
Avoids installing the package to the virtualenv before running the
commands. The package is not required to be installed to do simple
static code analysis or build the docs. Results in a slightly faster
run.

For additional information on the configuration option, see:

https://tox.readthedocs.io/en/latest/config.html#confval-skip_install=BOOL

> Do not install the current package. This can be used when you need the
> virtualenv management but do not want to install the current package
> into that environment.