### PR TITLE
Add support for very old versions of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,23 @@
 #! /usr/bin/env python
 
+import sys
+
 from setuptools import find_packages, setup
+
+# Very old versions of setuptools do not support the python version
+# specifier syntax, so logic must be defined in code (see issue #64).
+install_requires = []
+extras_require = {"icu": "PyICU >= 1.0.0"}
+if sys.version_info[:2] == (2, 6):
+    install_requires.append("argparse")
+else:
+    extras_require["fast"] = "fastnumbers >= 2.0.0"
+
 setup(
     name='natsort',
     version='5.4.1',
     packages=find_packages(),
-    install_requires=["argparse; python_version < '2.7'"],
+    install_requires=install_requires,
     entry_points={'console_scripts': ['natsort = natsort.__main__:main']},
-    extras_require={
-        'fast': ["fastnumbers >= 2.0.0; python_version > '2.6'"],
-        'icu': ["PyICU >= 1.0.0"]
-    }
+    extras_require=extras_require,
 )


### PR DESCRIPTION
The syntax "fastnumbers >= 2.0.0; python_version > 2.6" is "new" in the
sense that there are still OSs (like CentOS) that use still have
setuptools versions installed that do not support it.

The solution is to selectively add the dependency using logic rather
than declaratively.

This will solve issue #64.