### PR TITLE
CHANGELOG file extension in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -482,5 +482,5 @@ History
 -------
 
 Please visit the changelog
-`on GitHub <https://github.com/SethMMorton/natsort/blob/master/CHANGELOG.rst>`_ or
+`on GitHub <https://github.com/SethMMorton/natsort/blob/master/CHANGELOG.md>`_ or
 `in the documentation <https://natsort.readthedocs.io/en/master/changelog.html>`_.


### PR DESCRIPTION
The CHANGELOG file has the ".md" file extension not ".rst". See:

- https://github.com/SethMMorton/natsort/blob/master/CHANGELOG.rst
- https://github.com/SethMMorton/natsort/blob/master/CHANGELOG.md