### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: python
 cache:
   - pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ cache:
     - $HOME/.pyenv_cache
 python:
   - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Simple yet flexible natural sorting in Python.
 Quick Description
 -----------------
 
-When you try to sort a list of strings that contain numbers, the normal python
+When you try to sort a list of strings that contain numbers, the normal Python
 sort algorithm sorts lexicographically, so you might not get the results that you
 expect:
 
@@ -329,7 +329,7 @@ from the command line with ``python -m natsort``.
 Requirements
 ------------
 
-``natsort`` requires Python version 2.7 or Python 3.4 or greater.
+``natsort`` requires Python version 2.7 or Python 3.5 or greater.
 
 Optional Dependencies
 ---------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ classifiers =
 	Programming Language :: Python :: 2
 	Programming Language :: Python :: 2.7
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.4
 	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     version='6.0.0',
     packages=find_packages(),
     entry_points={'console_scripts': ['natsort = natsort.__main__:main']},
-    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     extras_require={
         'fast': ["fastnumbers >= 2.0.0"],
         'icu': ["PyICU >= 1.0.0"]

--- a/tox.ini
+++ b/tox.ini
@@ -5,8 +5,8 @@
 
 [tox]
 envlist =
-    flake8, py27, py34, py35, py36, py37, pypy
-# Other valid evironments are:
+    flake8, py27, py35, py36, py37, pypy
+# Other valid environments are:
 #   docs
 #   release
 


### PR DESCRIPTION
Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

It's also little used. Here's the pip installs for natsort from PyPI for July 2019:

| category | percent | downloads |
|----------|--------:|----------:|
| 2.7      |  33.28% |    70,233 |
| 3.7      |  24.17% |    51,013 |
| 3.6      |  24.07% |    50,797 |
| 3.5      |  16.43% |    34,684 |
| 3.4      |   1.57% |     3,322 |
| null     |   0.46% |       970 |
| 3.8      |   0.00% |        10 |
| 2.6      |   0.00% |         7 |
| 3.3      |   0.00% |         3 |
| Total    |         |   211,039 |

Source: `pip install -U pypistats && pypistats python_minor natsort --last-month`