### PR TITLE
Update docs to remove Python 2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,7 +329,7 @@ from the command line with ``python -m natsort``.
 Requirements
 ------------
 
-``natsort`` requires Python version 2.7 or Python 3.4 or greater.
+``natsort`` requires Python 3.4 or greater.
 
 Optional Dependencies
 ---------------------
@@ -428,7 +428,7 @@ Deprecation Schedule
 Dropping Python 2.7 Support
 +++++++++++++++++++++++++++
 
-``natsort`` version 7.0.0 will drop support for Python 2.7.
+``natsort`` version 7.0.0 drops support for Python 2.7.
 
 The version 6.X branch will remain as a "long term support" branch where bug fixes
 are applied so that users who cannot update from Python 2.7 will not be forced to

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -264,31 +264,6 @@ need to pass a key to the :meth:`list.sort` method. The function
 :func:`~natsort_keygen` has the same API as :func:`~natsorted` (minus the
 `reverse` option).
 
-Natural Sorting with ``cmp`` (Python 2 only)
---------------------------------------------
-
-.. note::
-    This is a Python2-only feature! The :func:`natcmp` function is not
-    exposed on Python3. Because this documentation is built with
-    Python3, you will not find :func:`natcmp` in the API.
-
-If you are using a legacy codebase that requires you to use :func:`cmp` instead
-of a key-function, you can use :func:`~natcmp`.
-
-.. code-block:: pycon
-
-    >>> import sys
-    >>> a = ['2 ft 7 in', '1 ft 5 in', '10 ft 2 in', '2 ft 11 in', '7 ft 6 in']
-    >>> if sys.version_info[0] == 2:
-    ...     from natsort import natcmp
-    ...     sorted(a, cmp=natcmp)
-    ... else:
-    ...     natsorted(a)  # so docstrings don't fail
-    ['1 ft 5 in', '2 ft 7 in', '2 ft 11 in', '7 ft 6 in', '10 ft 2 in']
-
-:func:`natcmp` also accepts an ``alg`` argument so you can customize your
-sorting experience.
-
 Sorting Multiple Lists According to a Single List
 -------------------------------------------------
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -324,7 +324,7 @@ from the command line with ``python -m natsort``.
 Requirements
 ------------
 
-:mod:`natsort` requires Python version 2.7 or Python 3.4 or greater.
+:mod:`natsort` requires Python 3.4 or greater.
 
 Optional Dependencies
 ---------------------
@@ -423,7 +423,7 @@ Deprecation Schedule
 Dropping Python 2.7 Support
 +++++++++++++++++++++++++++
 
-:mod:`natsort` version 7.0.0 will drop support for Python 2.7.
+:mod:`natsort` version 7.0.0 drops support for Python 2.7.
 
 The version 6.X branch will remain as a "long term support" branch where bug fixes
 are applied so that users who cannot update from Python 2.7 will not be forced to


### PR DESCRIPTION
This PR is against the `drop-python2` branch.