### PR TITLE
Deploy to PyPI from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,3 +91,28 @@ after_success:
 - coverage xml
 - python-codacy-coverage -r coverage.xml
 - codecov
+
+deploy:
+  - provider: pypi
+    server: https://test.pypi.org/legacy/
+    on:
+      tags: false
+      repo: SethMMorton/natsort
+      branch: master
+      python: 3.8
+    user: __token__
+    password:
+      secure: "TODO"
+    distributions: sdist --format=gztar bdist_wheel
+    skip_existing: true
+  - provider: pypi
+    on:
+      tags: true
+      repo: SethMMorton/natsort
+      branch: master
+      python: 3.8
+    user: __token__
+    password:
+      secure: "TODO"
+    distributions: sdist --format=gztar bdist_wheel
+    skip_existing: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,27 @@
+# Release Checklist
+
+- [ ] Get master to the appropriate code release state.
+      [Travis CI](https://travis-ci.org/SethMMorton/natsort) cleanly for all merges to
+      master.
+      [![Build Status](https://travis-ci.org/SethMMorton/natsort.svg?branch=master)](https://travis-ci.org/SethMMorton/natsort)
+
+- [ ] Tag with the version number:
+
+```bash
+git tag -a 6.3.0
+```
+
+- [ ] Push tag:
+
+```bash
+git push --tags
+```
+
+- [ ] Check the tagged [Travis CI build](https://travis-ci.org/SethMMorton/natsort) has
+      deployed to [PyPI](https://pypi.org/project/natsort/#history)
+
+- [ ] Check installation:
+
+```bash
+pip3 uninstall -y natsort && pip3 install -U natsort
+```


### PR DESCRIPTION
This should help make releasing easier.

* Deploy non-tagged builds to Test PyPI
* Deploy tagged builds to live PyPI

Will only trigger when run from the `SethMMorton/natsort` repo, on `master`, so not for forks or PRs.

The `on:` section shows the conditions for triggering an upload. This should be set up so only a single build job qualifies.

Right now, there's only a single Python 3.8 job, so select on `python: 3.8`. If 3.7 and 3.8 are switched, this can also so there's only a single 3.7. It's possible to select on other conditions too:

https://docs.travis-ci.com/user/deployment/#conditional-releases-with-on

`skip_existing: true` should in any case prevent trying to re-upload existing ones.


TODO:

1. Add an API token called (say) `natsort-ci` at https://test.pypi.org/manage/account/token/
2. On the command line, install the [Travis Client](https://github.com/travis-ci/travis.rb#installation)
3. Run `travis encrypt`
4. Paste in the token from step 1, it begins `pypi-`
5. Ctrl-D to end
6. Add the encrypted value as the first `password: secure: "TODO"` value
7. Repeat for production PyPI, put the encrypted value as the second `"TODO"`

More info on PyPI API tokens: https://pypi.org/help/#apitoken
