### PR TITLE
Do not fail on new python versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Unreleased
 ### Changed
  - MacOS unit tests run on native Python
  - Treate `None` like `NaN` internally to avoid `TypeError`
+ - No longer fail tests every time a new Python version is released (issue #122)
 
 ### Fixed
  - Various typos, missing figures, and out-of-date information in the "How it works"

--- a/dev/generate_new_unicode_numbers.py
+++ b/dev/generate_new_unicode_numbers.py
@@ -1,0 +1,45 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Generate the numeric hex list of unicode numerals
+"""
+import os
+import os.path
+import sys
+import unicodedata
+
+# This is intended to be called from project root. Enforce this.
+this_file = os.path.abspath(__file__)
+this_base = os.path.basename(this_file)
+cwd = os.path.abspath(os.getcwd())
+desired_this_file = os.path.join(cwd, "dev", this_base)
+if this_file != desired_this_file:
+    sys.exit(f"{this_base} must be called from project root")
+
+# We will write the new numeric hex collection to a natsort package file.
+target = os.path.join(cwd, "natsort", "unicode_numeric_hex.py")
+with open(target, "w") as fl:
+    print(
+        '''# -*- coding: utf-8 -*-
+"""
+Contains all possible non-ASCII unicode numbers.
+"""
+
+# Rather than determine what unicode characters are numeric on the fly which
+# would incur a startup runtime penalty, the hex values are hard-coded below.
+numeric_hex = (''',
+        file=fl,
+    )
+
+    # Write out each individual hex value.
+    for i in range(0x110000):
+        try:
+            a = chr(i)
+        except ValueError:
+            break
+        if a in "0123456789":
+            continue
+        if unicodedata.numeric(a, None) is not None:
+            print(f"    0x{i:X},", file=fl)
+
+    print(")", file=fl)

--- a/dev/generate_new_unicode_numbers.py
+++ b/dev/generate_new_unicode_numbers.py
@@ -14,7 +14,7 @@ this_base = os.path.basename(this_file)
 cwd = os.path.abspath(os.getcwd())
 desired_this_file = os.path.join(cwd, "dev", this_base)
 if this_file != desired_this_file:
-    sys.exit(f"{this_base} must be called from project root")
+    sys.exit(this_base + " must be called from project root")
 
 # We will write the new numeric hex collection to a natsort package file.
 target = os.path.join(cwd, "natsort", "unicode_numeric_hex.py")
@@ -40,6 +40,6 @@ numeric_hex = (''',
         if a in "0123456789":
             continue
         if unicodedata.numeric(a, None) is not None:
-            print(f"    0x{i:X},", file=fl)
+            print("    0x{:X},".format(i), file=fl)
 
     print(")", file=fl)

--- a/natsort/unicode_numeric_hex.py
+++ b/natsort/unicode_numeric_hex.py
@@ -1859,20 +1859,3 @@ numeric_hex = (
     0x2626D,
     0x2F890,
 )
-
-# Some code that can be used to create the above list of hex numbers.
-if __name__ == "__main__":
-    import unicodedata
-
-    hex_chars = []
-    for i in range(0x110000):
-        try:
-            a = chr(i)
-        except ValueError:
-            break
-        if a in "0123456789":
-            continue
-        if unicodedata.numeric(a, None) is not None:
-            hex_chars.append(i)
-
-    print(", ".join(["0X{:X}".format(i) for i in hex_chars]))

--- a/tests/test_unicode_numbers.py
+++ b/tests/test_unicode_numbers.py
@@ -4,6 +4,7 @@ Test the Unicode numbers module.
 """
 
 import unicodedata
+import warnings
 
 from natsort.unicode_numbers import (
     decimal_chars,
@@ -34,11 +35,21 @@ def test_decimal_chars_contains_only_valid_unicode_decimal_characters():
 
 
 def test_numeric_chars_contains_all_valid_unicode_numeric_and_digit_characters():
-    set_numeric_hex = set(numeric_hex)
     set_numeric_chars = set(numeric_chars)
     set_digit_chars = set(digit_chars)
     set_decimal_chars = set(decimal_chars)
-    for i in range(0X110000):
+
+    assert set_decimal_chars.isdisjoint(digits_no_decimals)
+    assert set_digit_chars.issuperset(digits_no_decimals)
+
+    assert set_decimal_chars.isdisjoint(numeric_no_decimals)
+    assert set_numeric_chars.issuperset(numeric_no_decimals)
+
+
+def test_missing_unicode_number_in_collection():
+    ok = True
+    set_numeric_hex = set(numeric_hex)
+    for i in range(0x110000):
         try:
             a = chr(i)
         except ValueError:
@@ -46,20 +57,16 @@ def test_numeric_chars_contains_all_valid_unicode_numeric_and_digit_characters()
         if a in "0123456789":
             continue
         if unicodedata.numeric(a, None) is not None:
-            assert i in set_numeric_hex
-            assert a in set_numeric_chars
-        if unicodedata.digit(a, None) is not None:
-            assert i in set_numeric_hex
-            assert a in set_digit_chars
-        if unicodedata.decimal(a, None) is not None:
-            assert i in set_numeric_hex
-            assert a in set_decimal_chars
-
-    assert set_decimal_chars.isdisjoint(digits_no_decimals)
-    assert set_digit_chars.issuperset(digits_no_decimals)
-
-    assert set_decimal_chars.isdisjoint(numeric_no_decimals)
-    assert set_numeric_chars.issuperset(numeric_no_decimals)
+            if i not in set_numeric_hex:
+                ok = False
+    if not ok:
+        warnings.warn(
+            """\
+Not all numeric unicode characters are represented in natsort/unicode_numeric_hex.py
+This can be addressed by running dev/generate_new_unicode_numbers.py with the current \
+version of Python.
+"""
+        )
 
 
 def test_combined_string_contains_all_characters_in_list():

--- a/tests/test_unicode_numbers.py
+++ b/tests/test_unicode_numbers.py
@@ -65,6 +65,8 @@ def test_missing_unicode_number_in_collection():
 Not all numeric unicode characters are represented in natsort/unicode_numeric_hex.py
 This can be addressed by running dev/generate_new_unicode_numbers.py with the current \
 version of Python.
+It would be much appreciated if you would submit a Pull Request to the natsort
+repository (https://github.com/SethMMorton/natsort) with the resulting change.
 """
         )
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 envlist =
-    flake8, py35, py36, py37, py38
+    flake8, py35, py36, py37, py38, py39
 # Other valid evironments are:
 #   docs
 #   release


### PR DESCRIPTION
This is intended to close #122.

However, it does not actually address the root cause. It just makes it so that the tests don't fail, and provides an easier and more obvious way for Good Samaritans to perform this upgrade when needed.