### PR TITLE
os_sorted: only convert input to str if necessary

### DIFF
--- a/natsort/natsort.py
+++ b/natsort/natsort.py
@@ -9,6 +9,7 @@ The majority of the "work" is defined in utils.py.
 import platform
 from functools import partial
 from operator import itemgetter
+from pathlib import PurePath
 from typing import (
     Any,
     Callable,
@@ -669,7 +670,9 @@ def _split_apply(
 ) -> Iterator[str]:
     if key is not None:
         v = key(v)
-    return utils.path_splitter(str(v))
+    if not isinstance(v, (str, PurePath)):
+        v = str(v)
+    return utils.path_splitter(v)
 
 
 # Choose the implementation based on the host OS


### PR DESCRIPTION
See https://github.com/SethMMorton/natsort/issues/157

I ran some benchmarks and I get a consistent 20% improvement when the inputs are `Path` already. Both for small lists and large lists (I tested lists with 10 and 10 000 items).

```python
from random import shuffle
from pathlib import Path
from timeit import repeat

from natsort import os_sorted

INPATH = "<path>"
paths = list(Path(INPATH).rglob("*"))
print(len(paths))
shuffle(paths)

# use smaller `number` for larger lists
print(min(repeat("os_sorted(paths)", repeat=10, number=1000, globals={"os_sorted": os_sorted, "paths": paths})))
```

I cannot run the test suite sadly since I get lots of `locale.Error: unsupported locale setting` errors.