### PR TITLE
Do not strip whitespace from CLI entries (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Unreleased
 
 ### Fixed
 
+- CLI no longer strips leading and trailing whitespace from entries, which
+  could change the sort order
+  ([@baldassarreFe](https://github.com/baldassarreFe), issue
+  [#181](https://github.com/SethMMorton/natsort/issues/181))
 - Eliminated mypy failure related to string literals
 
 ### Removed

--- a/natsort/__main__.py
+++ b/natsort/__main__.py
@@ -260,14 +260,16 @@ def get_entries(args: TypedArgs) -> list[str]:
     """Determine which entries to sort."""
     # Read entries from command line or stdin?
     # If reading from stdin, are entries split on nulls or newlines?
+    # Note: entries are intentionally not stripped of whitespace. Leading
+    # whitespace affects the sort order, so removing it would be surprising,
+    # and stripping trailing whitespace is an unnecessary modification of the
+    # input. The one exception is the trailing separator(s) left by reading
+    # from stdin, which are removed before splitting so they do not produce
+    # empty entries.
     if len(args.entries) > 0:
-        entries = args.entries
-    else:
-        separator = "\0" if args.zero_terminated else "\n"
-        entries = sys.stdin.read().rstrip(separator).split(separator)
-
-    # Remove trailing whitespace from all the entries
-    return [e.strip() for e in entries]
+        return args.entries
+    separator = "\0" if args.zero_terminated else "\n"
+    return sys.stdin.read().rstrip(separator).split(separator)
 
 
 def keep_entry_range(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -164,6 +164,47 @@ def test_get_entries(
     assert entries == ["num-2", "num-6", "num-1"]
 
 
+@pytest.mark.parametrize(
+    ("zero_terminated", "stdin_content"),
+    [
+        (False, " num-2\n num-6 \n num-1"),
+        (False, " num-2\n num-6 \n num-1\n"),
+        (True, " num-2\0 num-6 \0 num-1"),
+        (True, " num-2\0 num-6 \0 num-1\0"),
+    ],
+)
+def test_get_entries_does_not_strip_whitespace_from_stdin(
+    zero_terminated: bool,
+    stdin_content: str,
+    mocker: MockerFixture,
+) -> None:
+    """Test that whitespace within entries read from stdin is preserved."""
+    args = TypedArgs(zero_terminated=zero_terminated)
+    mock_stdin = mocker.patch("sys.stdin.read", return_value=stdin_content)
+    entries = get_entries(args)
+    mock_stdin.assert_called_once_with()
+    assert entries == [" num-2", " num-6 ", " num-1"]
+
+
+def test_get_entries_does_not_strip_whitespace_from_command_line() -> None:
+    """Test that whitespace within entries given on the command line is preserved."""
+    args = TypedArgs(entries=[" num-2", " num-6 ", "num-1 "])
+    assert get_entries(args) == [" num-2", " num-6 ", "num-1 "]
+
+
+@pytest.mark.parametrize("zero_terminated", [False, True])
+def test_get_entries_with_empty_stdin(
+    zero_terminated: bool,
+    mocker: MockerFixture,
+) -> None:
+    """Test that empty stdin yields a single empty entry."""
+    args = TypedArgs(zero_terminated=zero_terminated)
+    mock_stdin = mocker.patch("sys.stdin.read", return_value="")
+    entries = get_entries(args)
+    mock_stdin.assert_called_once_with()
+    assert entries == [""]
+
+
 # Each test has an "example" version for demonstrative purposes,
 # and a test that uses the hypothesis module.
 


### PR DESCRIPTION
## Summary

Fixes #181.

The CLI's `get_entries` in `natsort/__main__.py` stripped leading and
trailing whitespace from every entry via `e.strip()`, despite the comment
claiming it only removed *trailing* whitespace.

As discussed in the issue, the agreed behavior is to **not strip whitespace
at all**:

- Leading whitespace affects the natural sort order, so silently removing it
  is surprising and incorrect.
- Stripping trailing whitespace is an unnecessary modification of the input.

The trailing separator(s) left by reading from stdin are still removed
before splitting (via the existing `rstrip(separator)`), so they don't
produce empty entries.

### Example

Before, leading whitespace was discarded; now it is preserved and respected
when sorting:

```
$ python -m natsort 'tmp/a57/path2 ' '  tmp/a23/path1' ' tmp/a1/path1'
  tmp/a23/path1
 tmp/a1/path1
tmp/a57/path2
```

## Changes

- `natsort/__main__.py`: stop stripping entries; clarify the comment.
- `tests/test_main.py`: add tests that whitespace is preserved (stdin and
  command-line paths) and pin the empty-stdin behavior.
- `CHANGELOG.md`: add a `Fixed` entry.
