### PR TITLE
Only strip suffixes from the end of the base in path_splitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Unreleased
   could change the sort order
   ([@baldassarreFe](https://github.com/baldassarreFe), issue
   [#181](https://github.com/SethMMorton/natsort/issues/181))
+- `path_splitter` no longer removes extension text from the middle of a
+  file name when the same text also appears at the end, which corrupted
+  the `ns.PATH` sort order
+  ([@gaoflow](https://github.com/gaoflow), PR
+  [#191](https://github.com/SethMMorton/natsort/pull/191))
 - Eliminated mypy failure related to string literals
 
 ### Removed

--- a/natsort/utils.py
+++ b/natsort/utils.py
@@ -922,8 +922,9 @@ def path_splitter(
             suffixes.append(suffix)
         suffixes.reverse()
 
-    # Remove the suffixes from the base component
-    base = base.replace("".join(suffixes), "")
+    # Remove the suffixes from the end of the base component, taking care
+    # to not touch any earlier occurrences of the same text in the stem
+    base = base.removesuffix("".join(suffixes))
     base_component = [base] if base else []
 
     # Join all path comonents in an iterator

--- a/tests/test_natsorted.py
+++ b/tests/test_natsorted.py
@@ -225,6 +225,14 @@ def test_natsorted_path_extensions_heuristic() -> None:
     assert natsorted(given, alg=ns.PATH) == expected
 
 
+def test_natsorted_path_sorts_repeated_extension_by_true_stem() -> None:
+    # The ".jpg" in the middle of the stem must not be removed when
+    # building the sort key, or these sort in the wrong order.
+    given = ["imgApple.jpg", "img.jpg_banana.jpg", "img.jpg_apple.jpg"]
+    expected = ["img.jpg_apple.jpg", "img.jpg_banana.jpg", "imgApple.jpg"]
+    assert natsorted(given, alg=ns.PATH) == expected
+
+
 @pytest.mark.parametrize(
     ("alg", "expected"),
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -185,6 +185,46 @@ def test_path_splitter_splits_path_string_by_sep_and_removes_extension_example(
     assert tuple(utils.path_splitter(given)) == tuple(expected)
 
 
+@pytest.mark.parametrize(
+    ("given", "expected"),
+    [
+        ("img.jpg_backup.jpg", ("img.jpg_backup", ".jpg")),
+        ("backup.tar.gz_old.tar.gz", ("backup.tar.gz_old", ".tar", ".gz")),
+        ("a.tar_v1.0.tar", ("a.tar_v1.0", ".tar")),
+        (".jpg.jpg", (".jpg", ".jpg")),
+        ("směs.png_kopie.png", ("směs.png_kopie", ".png")),
+        ("dir.jpg/img.jpg_backup.jpg", ("dir.jpg", "img.jpg_backup", ".jpg")),
+    ],
+)
+def test_path_splitter_only_removes_extension_from_end(
+    given: str,
+    expected: tuple[str, ...],
+) -> None:
+    # The extension text may also appear earlier in the path - only the
+    # trailing occurrence is an extension.
+    assert tuple(utils.path_splitter(given)) == expected
+    assert tuple(utils.path_splitter(pathlib.Path(given))) == expected
+
+
+@given(text(alphabet=string.ascii_letters, min_size=1, max_size=4))
+def test_path_splitter_is_lossless_when_extension_repeats_in_stem(
+    ext: str,
+) -> None:
+    given = f"base.{ext}_copy.{ext}"
+    assert "".join(utils.path_splitter(given)) == given
+
+
+def test_path_splitter_keeps_distinct_names_distinct() -> None:
+    with_inner_extension = tuple(utils.path_splitter("img.jpg_backup.jpg"))
+    without = tuple(utils.path_splitter("img_backup.jpg"))
+    assert with_inner_extension != without
+
+
+def test_path_splitter_treat_base_false_ignores_repeated_extension() -> None:
+    given = "img.jpg_backup.jpg"
+    assert tuple(utils.path_splitter(given, treat_base=False)) == (given,)
+
+
 @given(lists(sampled_from(string.ascii_letters), min_size=3).filter(all))
 def test_path_splitter_splits_path_string_by_sep_and_removes_extension(
     x: list[str],


### PR DESCRIPTION
`path_splitter` strips the collected suffixes from the base component with `str.replace`, which removes *every* occurrence of that text, not just the trailing one:

```python
>>> tuple(path_splitter("img.jpg_backup.jpg"))
('img_backup', '.jpg')   # expected ('img.jpg_backup', '.jpg')
```

The corrupted stem makes `ns.PATH` sort such files in the wrong order, and distinct names can collide (`img.jpg_backup.jpg` and `img_backup.jpg` split identically). Since the collected suffixes are always the trailing suffixes of the base, `str.removesuffix` does exactly the right thing.
