### PR TITLE
fix: fall back to Decimal for large integers exceeding string conversion limit

### DIFF
--- a/natsort/compat/fake_fastnumbers.py
+++ b/natsort/compat/fake_fastnumbers.py
@@ -7,6 +7,7 @@ Used when the fastnumbers module is not installed.
 from __future__ import annotations
 
 import unicodedata
+from decimal import Decimal
 from typing import Callable, Union
 
 from natsort.unicode_numbers import decimal_chars
@@ -111,6 +112,8 @@ def fast_int(
         try:
             return int(x)
         except ValueError:
+            if x.lstrip("+-").isdigit():
+                return Decimal(x)
             try:
                 return _uni(x, key(x)) if len(x) == 1 else key(x)
             except TypeError:  # pragma: no cover


### PR DESCRIPTION
### Problem
In Python 3.11+, sorting standard filenames alongside an item containing more than 4,300 digits crashes `natsorted()` with `TypeError: '<' not supported between instances of 'str' and 'int'`.

In `natsort/compat/fake_fastnumbers.py`, when `int(x)` raises a `ValueError` due to CPython's string-to-integer conversion limit (`sys.get_int_max_str_digits()`), the exception block falls back to returning the raw string `key(x)`. During sorting tuple comparison against normal numbers, evaluating `int < str` raises an unhandled `TypeError`.

### Solution
When `int(x)` fails with a `ValueError`, verify if `x` represents a valid numeric sequence (`x.lstrip("+-").isdigit()`). If true, return `decimal.Decimal(x)` before falling back to string processing.

Unlike floating-point numbers which overflow to `inf` above `1e308`, `decimal.Decimal` supports arbitrary precision and natively interoperates with standard integers (`int`) during relational comparison (`<`, `>`, `==`) without triggering Python 3.11+ string-to-binary conversion boundaries or causing type errors.

### Verification
- Tested against reproduction script containing 5,000-digit filenames: sorting succeeds without error and orders arbitrary integers correctly at the end of the sequence.
- Full test suite verified with zero regressions.

cc @SethMMorton
