### PR TITLE
Convert digit runs exceeding the int/str limit in fast_int (#193)

### DIFF
--- a/natsort/compat/fake_fastnumbers.py
+++ b/natsort/compat/fake_fastnumbers.py
@@ -6,6 +6,7 @@ Used when the fastnumbers module is not installed.
 
 from __future__ import annotations
 
+import sys
 import unicodedata
 from typing import Callable, Union
 
@@ -111,6 +112,18 @@ def fast_int(
         try:
             return int(x)
         except ValueError:
+            # A long run of digits can exceed Python 3.11+'s int/str conversion
+            # limit (``sys.get_int_max_str_digits()``) and raise ValueError even
+            # though the string is a valid integer. Convert it with the limit
+            # lifted so natsort still sorts it numerically, matching the
+            # ``fastnumbers`` C extension (which has no such limit).
+            if x.lstrip("+-").isdigit() and hasattr(sys, "set_int_max_str_digits"):
+                previous = sys.get_int_max_str_digits()
+                sys.set_int_max_str_digits(0)
+                try:
+                    return int(x)
+                finally:
+                    sys.set_int_max_str_digits(previous)
             try:
                 return _uni(x, key(x)) if len(x) == 1 else key(x)
             except TypeError:  # pragma: no cover

--- a/tests/test_fake_fastnumbers.py
+++ b/tests/test_fake_fastnumbers.py
@@ -120,6 +120,18 @@ def test_fast_int_converts_int_string_to_int(x: int) -> None:
     assert fast_int(repr(x)) == x
 
 
+def test_fast_int_converts_int_string_exceeding_str_digit_limit() -> None:
+    # A run of digits longer than Python 3.11+'s int/str conversion limit is
+    # still a valid integer and must be converted (not returned as a string),
+    # or natsort raises a TypeError while sorting. Regression test for #193.
+    # ``10 ** n`` is computed numerically, so the expected value is built
+    # without tripping the string-conversion limit itself.
+    n = 4400  # more digits than the default limit of 4300
+    big = "1" + "0" * n
+    assert fast_int(big) == 10**n
+    assert fast_int("-" + big) == -(10**n)
+
+
 def test_fast_int_leaves_string_as_is_example() -> None:
     assert fast_int("invalid") == "invalid"
     assert fast_int("") == ""


### PR DESCRIPTION
Fixes #193.

## The bug

On Python 3.11+, `int(x)` raises `ValueError` when `x` has more digits than `sys.get_int_max_str_digits()` (default 4300). In `fake_fastnumbers.fast_int`, that `ValueError` was caught and the string returned, so a long numeric token became a `str` where natsort expects an `int` — and sorting an otherwise-valid list crashes:

```python
import natsort
natsort.natsorted(["a1", "a2", "a10", "a" + "1" * 5000])
# TypeError: '<' not supported between instances of 'str' and 'int'
```

## The fix

`fake_fastnumbers` exists to replicate the `fastnumbers` C extension, which has no such digit limit — so natsort already works on these inputs when `fastnumbers` is installed. This restores parity in the pure-Python fallback: an oversized-but-valid integer is converted with the limit temporarily lifted (`sys.set_int_max_str_digits`), so natsort sorts it numerically. Non-numeric strings and normal integers are unchanged. Added a regression test.

The core test suite passes locally. (Some pre-existing `locale`- and stdin-related tests error on Windows on a clean checkout too, unrelated to this change.)

Happy to adjust the approach if you'd rather handle oversized digit runs a different way (e.g. sorting them lexically).

---

*Disclosure: this change was prepared with AI assistance; I reviewed it and verified the tests before submitting.*
