### PR TITLE
Fix null_string_locale_max so it sorts after every PyICU key

### DIFF
--- a/natsort/compat/locale.py
+++ b/natsort/compat/locale.py
@@ -35,7 +35,7 @@ try:
     # This string should in theory be sorted after any other byte
     # string because it contains the max byte char repeated many times.
     # You would need some odd data to come after that.
-    null_string_locale_max = b"x7f" * 50
+    null_string_locale_max = b"\xff" * 50
 
     def dumb_sort() -> bool:
         """Determine if the locale backend is not collating correctly."""

--- a/tests/test_compat_locale.py
+++ b/tests/test_compat_locale.py
@@ -1,0 +1,45 @@
+"""Test the locale compatibility layer."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from typing import TYPE_CHECKING
+
+import pytest
+
+import natsort.compat.locale
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture
+def icu_locale_module() -> Iterator[types.ModuleType]:
+    """Load natsort/compat/locale.py with a stub "icu" module in place."""
+    saved = sys.modules.get("icu")
+    sys.modules["icu"] = types.ModuleType("icu")
+    spec = importlib.util.spec_from_file_location(
+        "_icu_locale", natsort.compat.locale.__file__
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        if saved is None:
+            del sys.modules["icu"]
+        else:
+            sys.modules["icu"] = saved
+
+
+def test_icu_null_string_locale_max_sorts_after_any_bytes(
+    icu_locale_module: types.ModuleType,
+) -> None:
+    # Prepended to numbers under ns.NUMAFTER | ns.LOCALE, so it must sort
+    # after every sort key PyICU can return.
+    assert icu_locale_module.null_string_locale_max > b"\xff" * 49
+    assert icu_locale_module.null_string_locale_max > b"\xfe" * 100


### PR DESCRIPTION
`null_string_locale_max` in `natsort/compat/locale.py` (the PyICU branch) is `b"x7f" * 50`, which is the three ASCII bytes `x`, `7`, `f` repeated, not the byte 0x7f. It is the sentinel prepended under `ns.NUMAFTER | ns.LOCALE` so numbers sort after strings, but any sort key whose first byte is above `x` (0x78) already sorts after it, so `b"x7f"*50 > b"y"` is `False`.

Change: `b"\xff" * 50`, the actual maximum byte, one line. Added `tests/test_compat_locale.py`, which loads the module with a stub `icu` in `sys.modules` and checks the sentinel against `b"\xff" * 49` and `b"\xfe" * 100`. It fails on the current constant and passes with the change.

Verified on a fresh clone at e90771d: `pytest` 355 passed, `ruff format --check`, `ruff check` (no new findings beyond the CPY001 every file already reports on ruff 0.16.5), `mypy --strict natsort tests` unchanged from main. I could not install PyICU on this host (no ICU headers), so the PyICU code path itself was exercised only through the stub; CI installs `libicu-dev` and should cover it.

Found while running an AI-assisted code review on this repository; the change and the test are mine and were verified as described.
