### PR TITLE
Fix TypeError sorting a numeric token longer than the int() str-digit limit

### DIFF
--- a/natsort/compat/fake_fastnumbers.py
+++ b/natsort/compat/fake_fastnumbers.py
@@ -6,10 +6,41 @@ Used when the fastnumbers module is not installed.
 
 from __future__ import annotations
 
+import sys
 import unicodedata
-from typing import Callable, Union
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Callable, Union
 
 from natsort.unicode_numbers import decimal_chars
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+# Python 3.11 added a guard rail that makes int() (and str(int)) raise
+# ValueError for digit runs longer than sys.get_int_max_str_digits(),
+# to keep a hostile huge numeric string from stalling a program. The
+# fastnumbers C extension that this module stands in for has no such
+# limit, so without accounting for it here, a natsort call would behave
+# differently for an oversized numeric token depending on whether that
+# optional dependency happens to be installed: a plain string (that no
+# longer sorts consistently with the other, ordinarily-sized numbers
+# next to it) versus an int.
+_HAS_INT_MAX_STR_DIGITS = hasattr(sys, "set_int_max_str_digits")
+
+
+@contextmanager
+def _int_max_str_digits_disabled() -> Iterator[None]:
+    """Temporarily lift the int() digit-count guard rail, if it exists."""
+    if not _HAS_INT_MAX_STR_DIGITS:
+        yield
+        return
+    previous_limit = sys.get_int_max_str_digits()
+    sys.set_int_max_str_digits(0)
+    try:
+        yield
+    finally:
+        sys.set_int_max_str_digits(previous_limit)
+
 
 _NAN_INF = [
     "INF",
@@ -111,6 +142,14 @@ def fast_int(
         try:
             return int(x)
         except ValueError:
+            unsigned = x[1:] if x[:1] in "+-" else x
+            if unsigned.isdecimal():
+                # This wasn't "not an int"; it was int() refusing a
+                # too-long-but-otherwise-perfectly-valid digit run
+                # (see _int_max_str_digits_disabled above). Convert it
+                # anyway so it keeps sorting as a number.
+                with _int_max_str_digits_disabled():
+                    return int(x)
             try:
                 return _uni(x, key(x)) if len(x) == 1 else key(x)
             except TypeError:  # pragma: no cover

--- a/tests/test_fake_fastnumbers.py
+++ b/tests/test_fake_fastnumbers.py
@@ -4,10 +4,12 @@ Test the fake fastnumbers module.
 
 from __future__ import annotations
 
+import sys
 import unicodedata
 from math import isinf
 from typing import cast
 
+import pytest
 from hypothesis import given
 from hypothesis.strategies import floats, integers, text
 
@@ -138,3 +140,31 @@ def test_fast_int_with_key_applies_to_string_example() -> None:
 @given(text().filter(not_an_int))
 def test_fast_int_with_key_applies_to_string(x: str) -> None:
     assert fast_int(x, key=lambda x: x.upper()) == x.upper()
+
+
+@pytest.mark.skipif(
+    not hasattr(sys, "set_int_max_str_digits"),
+    reason="int digit limit was added in Python 3.11",
+)
+def test_fast_int_converts_digit_run_beyond_the_str_conversion_limit() -> None:
+    # Regression test: on Python 3.11+, plain int() raises ValueError for a
+    # digit run longer than sys.get_int_max_str_digits() (4300 by default).
+    # fast_int used to fall back to returning such a string as-is, which
+    # made it silently masquerade as "not a number" even though it plainly
+    # is one, and would later blow up natsorted() with a TypeError when
+    # compared against a sibling int at the same tuple position.
+    digits = "9" * 5000
+    original_limit = sys.get_int_max_str_digits()
+    try:
+        sys.set_int_max_str_digits(0)
+        expected = int(digits)
+    finally:
+        sys.set_int_max_str_digits(original_limit)
+
+    assert fast_int(digits) == expected
+    assert fast_int("-" + digits) == -expected
+    assert fast_int("+" + digits) == expected
+
+    # The limit must be restored to whatever it was before, not left
+    # disabled as a side effect of converting the oversized number.
+    assert sys.get_int_max_str_digits() == original_limit

--- a/tests/test_natsorted.py
+++ b/tests/test_natsorted.py
@@ -428,3 +428,18 @@ def test_natsort_sorts_consistently_with_presort() -> None:
     given = ["a1", "a1.45", "a01", "a1.4500"]
     result = natsorted(given, alg=ns.FLOAT | ns.PRESORT)
     assert result == expected
+
+
+def test_natsorted_handles_a_digit_run_longer_than_the_str_conversion_limit() -> None:
+    # Regression test for a crash on Python 3.11+: a numeric substring
+    # with more digits than sys.get_int_max_str_digits() (4300 by
+    # default) used to make int() raise inside the pure-Python fallback,
+    # which was swallowed and the whole token kept as a plain string
+    # instead. That string then sat right next to an ordinary int at
+    # the same tuple position for a sibling entry, and comparing them
+    # during the sort raised "TypeError: '<' not supported between
+    # instances of 'str' and 'int'".
+    huge_digit_run = "9" * 5000
+    given = ["item_10.png", "item_2.png", f"item_{huge_digit_run}.png"]
+    expected = ["item_2.png", "item_10.png", f"item_{huge_digit_run}.png"]
+    assert natsorted(given) == expected


### PR DESCRIPTION
Fixes #193.

## The bug

On Python 3.11+, `int()` raises `ValueError` when the string it is given has more digits than `sys.get_int_max_str_digits()` (4300 by default). In `natsort/compat/fake_fastnumbers.py`, `fast_int` catches that `ValueError` the same way it catches a genuine "this isn't a number" failure, and falls back to returning the original text as a plain string.

That means an oversized numeric token quietly becomes a `str` while an ordinarily-sized numeric token elsewhere in the same input stays an `int`. `natsort` builds its sort keys as tuples that alternate string and number, counting on same-shaped inputs producing same-shaped tuples, so once one entry's key has a `str` sitting where another entry's key has an `int`, the actual `sorted()` call blows up:

```python
import natsort
natsort.natsorted(["item_10.png", "item_2.png", "item_" + "9" * 5000 + ".png"])
# TypeError: '<' not supported between instances of 'str' and 'int'
```

This only affects the pure-Python fallback used when the optional `fastnumbers` C extension isn't installed. `fastnumbers` has no equivalent digit limit, so the same input sorts fine with it installed, which is what makes this particularly confusing to hit.

## The fix

`fast_int` now checks, on the `ValueError` path, whether the text (after an optional leading sign) is a plain run of decimal digits. If it is, the failure was the digit-count guard rail rather than an actual non-numeric string, so it converts the value anyway with the limit temporarily disabled for that call (restored immediately after via a small context manager), rather than downgrading a valid integer into a string.

`sys.set_int_max_str_digits` only exists on 3.11+, so the whole thing is a no-op (behaves exactly as before) on earlier versions, which this repo still supports.

## Tests

Added a direct unit test for `fast_int` on a 5000-digit string (covering unsigned, `+`, and `-`), including a check that the digit limit is restored to its prior value afterward, plus an end-to-end `natsorted` test that reproduces the crash from the report. Both new tests fail against the old code and pass with the fix. The full existing suite (356 tests) still passes.